### PR TITLE
FSO-303: Слайды на календаре расписания

### DIFF
--- a/src/pages/planning/ui/calendar.css
+++ b/src/pages/planning/ui/calendar.css
@@ -10,7 +10,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    min-width: 0;
+    min-inline-size: 0;
 
     &_today {
       color: var(--clr-brand-6);

--- a/src/pages/planning/ui/calendar.css
+++ b/src/pages/planning/ui/calendar.css
@@ -10,6 +10,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    min-width: 0;
 
     &_today {
       color: var(--clr-brand-6);

--- a/src/pages/planning/ui/calendar.tsx
+++ b/src/pages/planning/ui/calendar.tsx
@@ -8,6 +8,15 @@ export interface CalendarDate {
   year: number;
 }
 
+// shitty way to create keys for comparison of CalendarDates
+// cause createSelector compares by reference (===)
+const getCalendarDateKey = (date: CalendarDate | undefined) => {
+  if (!date) {
+    return '';
+  }
+  return `${date.year}-${date.month}-${date.day}`;
+};
+
 export interface CalendarRowSectionProps extends JSX.HTMLAttributes<HTMLDivElement> {
   days?: CalendarDate[];
   today?: CalendarDate;
@@ -16,17 +25,14 @@ export interface CalendarRowSectionProps extends JSX.HTMLAttributes<HTMLDivEleme
 }
 
 export function CalendarRowSection(props: CalendarRowSectionProps) {
-  const isSelected = createSelector(() => props.selectedDay);
+  const isSelected = createSelector(() => getCalendarDateKey(props.selectedDay));
 
   const classModifier = (day: CalendarDate) => {
-    if (isSelected(day)) {
+    const key = getCalendarDateKey(day);
+    if (isSelected(key)) {
       return 'calendar-row__cell_selected';
     }
-    if (
-      day.day === props?.today?.day &&
-      day.month === props?.today?.month &&
-      day.year === props?.today?.year
-    ) {
+    if (getCalendarDateKey(props.today) === key) {
       return 'calendar-row__cell_today';
     }
     return '';

--- a/src/pages/planning/ui/calendar.tsx
+++ b/src/pages/planning/ui/calendar.tsx
@@ -1,26 +1,32 @@
 import './calendar.css';
 import { createSelector, For, type JSX } from 'solid-js';
 
-export interface Day {
+export interface CalendarDate {
   dayOfWeek: string;
-  date: number;
+  day: number;
+  month: number;
+  year: number;
 }
 
 export interface CalendarRowSectionProps extends JSX.HTMLAttributes<HTMLDivElement> {
-  days?: Day[];
-  today?: number;
-  currentDay?: number;
-  onDateClick: (day: number) => void;
+  days?: CalendarDate[];
+  today?: CalendarDate;
+  selectedDay?: CalendarDate;
+  onDateClick: (day: CalendarDate) => void;
 }
 
 export function CalendarRowSection(props: CalendarRowSectionProps) {
-  const isSelected = createSelector(() => props.currentDay);
+  const isSelected = createSelector(() => props.selectedDay);
 
-  const classModifier = (day: number) => {
+  const classModifier = (day: CalendarDate) => {
     if (isSelected(day)) {
       return 'calendar-row__cell_selected';
     }
-    if (day === props.today) {
+    if (
+      day.day === props?.today?.day &&
+      day.month === props?.today?.month &&
+      day.year === props?.today?.year
+    ) {
       return 'calendar-row__cell_today';
     }
     return '';
@@ -31,10 +37,10 @@ export function CalendarRowSection(props: CalendarRowSectionProps) {
       <For each={props.days}>
         {(day) => (
           <div
-            class={`calendar-row__cell ${classModifier(day.date)}`}
-            onClick={[props.onDateClick, day.date]}
+            class={`calendar-row__cell ${classModifier(day)}`}
+            onClick={[props.onDateClick, day]}
           >
-            <div>{day.date}</div>
+            <div>{day.day}</div>
             <div>{day.dayOfWeek}</div>
           </div>
         )}

--- a/src/pages/planning/ui/date.ts
+++ b/src/pages/planning/ui/date.ts
@@ -1,4 +1,4 @@
-import { type Day } from './calendar';
+import { type CalendarDate } from './calendar';
 
 export function getDateFormatted(date: Date): string {
   const formatter = new Intl.DateTimeFormat('ru-RU', {
@@ -10,11 +10,11 @@ export function getDateFormatted(date: Date): string {
   return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 }
 
-export interface ExtendedDay extends Day {
+export interface ExtendedDay extends CalendarDate {
   dateObj: Date;
 }
 
-export function getCurrentWeek(time: Date): ExtendedDay[] {
+export function getWeek(time: Date): ExtendedDay[] {
   const dayOfWeek = time.getDay();
 
   // because week starts from sunday
@@ -30,11 +30,19 @@ export function getCurrentWeek(time: Date): ExtendedDay[] {
   for (let i = 0; i < 7; i++) {
     const current = new Date(day);
     week.push({
-      date: current.getDate(),
+      day: current.getDate(),
       dayOfWeek: formatter.format(current),
+      month: current.getMonth() + 1,
+      year: current.getFullYear(),
       dateObj: new Date(current),
     });
     day.setDate(day.getDate() + 1);
   }
   return week;
+}
+
+export function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
 }

--- a/src/pages/planning/ui/date.ts
+++ b/src/pages/planning/ui/date.ts
@@ -32,7 +32,7 @@ export function getWeek(time: Date): ExtendedDay[] {
     week.push({
       day: current.getDate(),
       dayOfWeek: formatter.format(current),
-      month: current.getMonth() + 1,
+      month: current.getMonth(),
       year: current.getFullYear(),
       dateObj: new Date(current),
     });

--- a/src/pages/planning/ui/schedule.css
+++ b/src/pages/planning/ui/schedule.css
@@ -24,7 +24,7 @@
   &__calendar-track {
     display: flex;
     inline-size: 300%;
-    transform: translateX(calc(-100% / 3));
+    transform: translateX(-33.333%);
     transition: none;
     touch-action: pan-y;
     user-select: none;

--- a/src/pages/planning/ui/schedule.css
+++ b/src/pages/planning/ui/schedule.css
@@ -26,6 +26,9 @@
     inline-size: 300%;
     transform: translateX(-33.33%);
     transition: none;
+    touch-action: pan-y;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   &__calendar-slide {

--- a/src/pages/planning/ui/schedule.css
+++ b/src/pages/planning/ui/schedule.css
@@ -24,15 +24,17 @@
   &__calendar-track {
     display: flex;
     inline-size: 300%;
-    transform: translateX(-33.33%);
+    transform: translateX(calc(-100% / 3));
     transition: none;
     touch-action: pan-y;
     user-select: none;
     -webkit-user-select: none;
+    will-change: transform;
   }
 
   &__calendar-slide {
-    inline-size: 33.33%;
+    inline-size: calc(100% / 3);
+    flex-shrink: 0;
   }
 
   &__intake-record-list {

--- a/src/pages/planning/ui/schedule.css
+++ b/src/pages/planning/ui/schedule.css
@@ -14,10 +14,22 @@
     color: var(--clr-brand-6);
   }
 
-  &__calendar-row {
+  &__calendar-window {
+    overflow: hidden;
     inline-size: 100%;
     max-inline-size: var(--size-10);
     margin-inline: auto;
+  }
+
+  &__calendar-track {
+    display: flex;
+    inline-size: 300%;
+    transform: translateX(-33.33%);
+    transition: none;
+  }
+
+  &__calendar-slide {
+    inline-size: 33.33%;
   }
 
   &__intake-record-list {

--- a/src/pages/planning/ui/schedule.tsx
+++ b/src/pages/planning/ui/schedule.tsx
@@ -21,6 +21,7 @@ export function SchedulePage() {
   });
 
   const [anchorDate, setAnchorDate] = createSignal(new Date());
+  // create 3 weeks: previous, current and next for swipe purposes
   const weeks: () => ExtendedDay[][] = createMemo(() => {
     const date = new Date(anchorDate());
     return [getWeek(addDays(date, -7)), getWeek(date), getWeek(addDays(date, 7))];
@@ -29,19 +30,11 @@ export function SchedulePage() {
   const currentDay: CalendarDate = {
     day: currentDate.getDate(),
     dayOfWeek: currentDate.toLocaleDateString('ru-RU', { weekday: 'short' }),
-    month: currentDate.getMonth() + 1,
+    month: currentDate.getMonth(),
     year: currentDate.getFullYear(),
   };
   const [selectedDay, setSelectedDay] = createSignal(currentDay);
-  const selectedDate = createMemo(() => {
-    return weeks()[1].find((d) => {
-      return (
-        d.day === selectedDay().day &&
-        d.month === selectedDay().month &&
-        d.year === selectedDay().year
-      );
-    })?.dateObj;
-  });
+  const [selectedDate, setSelectedDate] = createSignal(currentDate);
 
   const timeFormatter = Intl.DateTimeFormat('ru-RU', {
     hour: '2-digit',
@@ -80,6 +73,11 @@ export function SchedulePage() {
   let swipeStartX = 0;
   let currentTransform = 0;
 
+  const DRAG_THRESHOLD = 10;
+  const SWIPE_THRESHOLD_PERCENTAGE = 30;
+  const TRANSITION_NONE = 'none';
+  const TRANSITION_TRANSFORM = 'transform 0.5s ease-in-out';
+
   const pointerDownHandler = (e: PointerEvent) => {
     const elem = e.currentTarget as HTMLElement;
     // cause there are 3 week rows in a track (previous, current and next).
@@ -88,7 +86,7 @@ export function SchedulePage() {
     swipeStartX = e.clientX;
     isPointerHold = true;
 
-    elem.style.transition = 'none';
+    elem.style.transition = TRANSITION_NONE;
   };
 
   const pointerMoveHandler = (e: PointerEvent) => {
@@ -97,8 +95,7 @@ export function SchedulePage() {
     }
 
     const diffX = e.clientX - swipeStartX;
-    const dragThreshold = 10;
-    if (Math.abs(diffX) <= dragThreshold) {
+    if (Math.abs(diffX) <= DRAG_THRESHOLD) {
       // got a small move, assume is's as a click.
       // it's necessary to handle click on date cells.
       return;
@@ -112,7 +109,13 @@ export function SchedulePage() {
     elem.style.transform = `translateX(${currentTransform}px)`;
   };
 
-  let weekSwipeDirection = 0; // -1 - previous week, 0 - current week, 1 - next week
+  enum SwipeDirection {
+    NoSwipe,
+    Previous,
+    Next,
+  }
+
+  let weekSwipeDirection = SwipeDirection.NoSwipe;
   const pointerUpHandler = (e: PointerEvent) => {
     if (isPointerHold && !isDrag) {
       // no swipe just a click
@@ -126,30 +129,39 @@ export function SchedulePage() {
     const diffTransform = currentTransform - -calendarRowWidth; // by default translateX is negative
 
     // need to adjust CalendarRow position after swipe: Monday is left and Sunday is right.
-    const swipeThreshold = 0.6 * calendarRowWidth;
+    const swipeThreshold = (SWIPE_THRESHOLD_PERCENTAGE / 100) * calendarRowWidth;
     let adjustedTransform = -calendarRowWidth;
     if (diffTransform > swipeThreshold) {
-      adjustedTransform = 0;
-      weekSwipeDirection = -1;
+      weekSwipeDirection = SwipeDirection.Previous;
+      adjustedTransform = 0; // index of previous week
     } else if (diffTransform < -swipeThreshold) {
-      adjustedTransform = -2 * calendarRowWidth;
-      weekSwipeDirection = 1;
+      weekSwipeDirection = SwipeDirection.Next;
+      adjustedTransform = 2 * -calendarRowWidth; // index of next week
     }
 
     currentTransform = 0;
-    elem.style.transition = `transform 0.5s ease-in-out`;
+    elem.style.transition = TRANSITION_TRANSFORM;
     elem.style.transform = `translateX(${adjustedTransform}px)`;
   };
 
   const transitionEndHandler = (e: TransitionEvent) => {
-    if (weekSwipeDirection === 0) {
+    if (weekSwipeDirection === SwipeDirection.NoSwipe) {
       return;
     }
 
-    setAnchorDate((date) => addDays(date, weekSwipeDirection * 7));
+    switch (weekSwipeDirection) {
+      case SwipeDirection.Previous:
+        setAnchorDate((date) => addDays(date, -7));
+        break;
+      case SwipeDirection.Next:
+        setAnchorDate((date) => addDays(date, 7));
+        break;
+      default:
+        console.error('unknown swipe direction:', weekSwipeDirection);
+    }
 
     const elem = e.currentTarget as HTMLElement;
-    elem.style.transition = 'none';
+    elem.style.transition = TRANSITION_NONE;
     elem.style.transform = `translateX(${-calendarRowWidth}px)`;
     weekSwipeDirection = 0;
   };
@@ -157,7 +169,7 @@ export function SchedulePage() {
   return (
     <main class="schedule-page">
       <section class="schedule-page__calendar">
-        <div class="schedule-page__current-date">{getDateFormatted(currentDate)}</div>
+        <div class="schedule-page__current-date">{getDateFormatted(selectedDate())}</div>
         <div class="schedule-page__calendar-window">
           <div
             class="schedule-page__calendar-track"
@@ -177,6 +189,7 @@ export function SchedulePage() {
                       selectedDay={selectedDay()}
                       onDateClick={(day: CalendarDate) => {
                         setSelectedDay(day);
+                        setSelectedDate(new Date(day.year, day.month, day.day));
                       }}
                     />
                   </div>

--- a/src/pages/planning/ui/schedule.tsx
+++ b/src/pages/planning/ui/schedule.tsx
@@ -1,9 +1,9 @@
 import { createResource, createSignal, Suspense } from 'solid-js';
 import { useLayoutStore } from '@/widgets/layouts';
-import { CalendarRowSection } from './calendar';
+import { CalendarRowSection, type CalendarDate } from './calendar';
 import './schedule.css';
 import { EmptyScreen } from '@/shared/ui/empty_screen/empty_screen';
-import { ExtendedDay, getCurrentWeek, getDateFormatted } from './date';
+import { type ExtendedDay, getWeek, getDateFormatted, addDays } from './date';
 import { createMemo, Show } from 'solid-js';
 import { IntakeRecordCard, usePlanStore } from '@/entities/plan';
 import { For } from 'solid-js';
@@ -20,13 +20,27 @@ export function SchedulePage() {
     title: 'Расписание',
   });
 
-  const date = new Date();
-  const days: ExtendedDay[] = getCurrentWeek(date);
-  const currentDay = date.getDate();
-
+  const [anchorDate, setAnchorDate] = createSignal(new Date());
+  const weeks: () => ExtendedDay[][] = createMemo(() => {
+    const date = new Date(anchorDate());
+    return [getWeek(addDays(date, -7)), getWeek(date), getWeek(addDays(date, 7))];
+  });
+  const currentDate = new Date();
+  const currentDay: CalendarDate = {
+    day: currentDate.getDate(),
+    dayOfWeek: currentDate.toLocaleDateString('ru-RU', { weekday: 'short' }),
+    month: currentDate.getMonth() + 1,
+    year: currentDate.getFullYear(),
+  };
   const [selectedDay, setSelectedDay] = createSignal(currentDay);
   const selectedDate = createMemo(() => {
-    return days.find((d) => d.date === selectedDay())?.dateObj;
+    return weeks()[1].find((d) => {
+      return (
+        d.day === selectedDay().day &&
+        d.month === selectedDay().month &&
+        d.year === selectedDay().year
+      );
+    })?.dateObj;
   });
 
   const timeFormatter = Intl.DateTimeFormat('ru-RU', {
@@ -60,19 +74,115 @@ export function SchedulePage() {
     { ssrLoadFrom: 'initial' },
   );
 
+  let calendarRowWidth = 0;
+  let isDrag = false;
+  let isPointerHold = false;
+  let swipeStartX = 0;
+  let currentTransform = 0;
+
+  const pointerDownHandler = (e: PointerEvent) => {
+    const elem = e.currentTarget as HTMLElement;
+    // cause there are 3 week rows in a track (previous, current and next).
+    calendarRowWidth = elem.getBoundingClientRect().width / 3;
+
+    swipeStartX = e.clientX;
+    isPointerHold = true;
+
+    elem.style.transition = 'none';
+  };
+
+  const pointerMoveHandler = (e: PointerEvent) => {
+    if (!isPointerHold) {
+      return;
+    }
+
+    const diffX = e.clientX - swipeStartX;
+    const dragThreshold = 10;
+    if (Math.abs(diffX) <= dragThreshold) {
+      // got a small move, assume is's as a click.
+      // it's necessary to handle click on date cells.
+      return;
+    }
+
+    currentTransform = diffX + -calendarRowWidth;
+    isDrag = true;
+
+    const elem = e.currentTarget as HTMLElement;
+    elem.setPointerCapture(e.pointerId);
+    elem.style.transform = `translateX(${currentTransform}px)`;
+  };
+
+  let weekSwipeDirection = 0; // -1 - previous week, 0 - current week, 1 - next week
+  const pointerUpHandler = (e: PointerEvent) => {
+    if (isPointerHold && !isDrag) {
+      // no swipe just a click
+      isPointerHold = false;
+      return;
+    }
+    isDrag = false;
+    isPointerHold = false;
+
+    const elem = e.currentTarget as HTMLElement;
+    const diffTransform = currentTransform - -calendarRowWidth; // by default translateX is negative
+
+    // need to adjust CalendarRow position after swipe: Monday is left and Sunday is right.
+    const swipeThreshold = 0.6 * calendarRowWidth;
+    let adjustedTransform = -calendarRowWidth;
+    if (diffTransform > swipeThreshold) {
+      adjustedTransform = 0;
+      weekSwipeDirection = -1;
+    } else if (diffTransform < -swipeThreshold) {
+      adjustedTransform = -2 * calendarRowWidth;
+      weekSwipeDirection = 1;
+    }
+
+    currentTransform = 0;
+    elem.style.transition = `transform 0.5s ease-in-out`;
+    elem.style.transform = `translateX(${adjustedTransform}px)`;
+  };
+
+  const transitionEndHandler = (e: TransitionEvent) => {
+    if (weekSwipeDirection === 0) {
+      return;
+    }
+
+    setAnchorDate((date) => addDays(date, weekSwipeDirection * 7));
+
+    const elem = e.currentTarget as HTMLElement;
+    elem.style.transition = 'none';
+    elem.style.transform = `translateX(${-calendarRowWidth}px)`;
+    weekSwipeDirection = 0;
+  };
+
   return (
     <main class="schedule-page">
       <section class="schedule-page__calendar">
-        <div class="schedule-page__current-date">{getDateFormatted(date)}</div>
-        <div class="schedule-page__calendar-row">
-          <CalendarRowSection
-            days={days}
-            today={currentDay}
-            currentDay={selectedDay()}
-            onDateClick={(day: number) => {
-              setSelectedDay(day);
-            }}
-          />
+        <div class="schedule-page__current-date">{getDateFormatted(currentDate)}</div>
+        <div class="schedule-page__calendar-window">
+          <div
+            class="schedule-page__calendar-track"
+            onPointerDown={pointerDownHandler}
+            onPointerUp={pointerUpHandler}
+            onPointerMove={pointerMoveHandler}
+            onTransitionEnd={transitionEndHandler}
+          >
+            <For each={weeks()}>
+              {(week) => {
+                return (
+                  <div class="schedule-page__calendar-slide">
+                    <CalendarRowSection
+                      days={week}
+                      today={currentDay}
+                      selectedDay={selectedDay()}
+                      onDateClick={(day: CalendarDate) => {
+                        setSelectedDay(day);
+                      }}
+                    />
+                  </div>
+                );
+              }}
+            </For>
+          </div>
         </div>
       </section>
       <Suspense fallback={<CenteredLoaderSpinner />}>

--- a/src/pages/planning/ui/schedule.tsx
+++ b/src/pages/planning/ui/schedule.tsx
@@ -164,6 +164,7 @@ export function SchedulePage() {
             onPointerDown={pointerDownHandler}
             onPointerUp={pointerUpHandler}
             onPointerMove={pointerMoveHandler}
+            onPointerCancel={pointerUpHandler}
             onTransitionEnd={transitionEndHandler}
           >
             <For each={weeks()}>


### PR DESCRIPTION
Заебся кокретно, но сделал. Теперь можно слайдами переключать недели в расписании.
Для реализации использовал PointerEvents - универсальные как для мыши, так и для сенсоров.
Есть и некоторые колхозные вещи, например сравнения объектов из createSelector. Если есть оптимальные идеи реализации, готов выслушать.

https://github.com/user-attachments/assets/bd9b5553-2071-46ce-9d6d-5309fb6dcee1

